### PR TITLE
Pull Request for a3

### DIFF
--- a/doc/894391.patch
+++ b/doc/894391.patch
@@ -1,0 +1,54 @@
+diff --git a/toolkit/components/thumbnails/PageThumbs.jsm b/toolkit/components/thumbnails/PageThumbs.jsm
+index 3ffc836..d26dba2 100644
+--- a/toolkit/components/thumbnails/PageThumbs.jsm
++++ b/toolkit/components/thumbnails/PageThumbs.jsm
+@@ -30,9 +30,7 @@ XPCOMUtils.defineLazyGlobalGetters(this, ["FileReader"]);
+ 
+ XPCOMUtils.defineLazyModuleGetters(this, {
+   Services: "resource://gre/modules/Services.jsm",
+-  FileUtils: "resource://gre/modules/FileUtils.jsm",
+   PlacesUtils: "resource://gre/modules/PlacesUtils.jsm",
+-  Deprecated: "resource://gre/modules/Deprecated.jsm",
+   AsyncShutdown: "resource://gre/modules/AsyncShutdown.jsm",
+   PageThumbUtils: "resource://gre/modules/PageThumbUtils.jsm",
+   PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.jsm",
+@@ -688,16 +686,6 @@ var PageThumbsStorage = {
+       }
+     };
+   },
+-
+-  // Deprecated, please do not use
+-  getFileForURL: function Storage_getFileForURL_DEPRECATED(aURL) {
+-    Deprecated.warning(
+-      "PageThumbs.getFileForURL is deprecated. Please use PageThumbs.getFilePathForURL and OS.File",
+-      "https://developer.mozilla.org/docs/JavaScript_OS.File"
+-    );
+-    // Note: Once this method has been removed, we can get rid of the dependency towards FileUtils
+-    return new FileUtils.File(PageThumbsStorageService.getFilePathForURL(aURL));
+-  },
+ };
+ 
+ var PageThumbsStorageMigrator = {
+diff --git a/toolkit/components/thumbnails/test/browser_thumbnails_storage_migrate3.js b/toolkit/components/thumbnails/test/browser_thumbnails_storage_migrate3.js
+index 7ac1ce4..caa48ff 100644
+--- a/toolkit/components/thumbnails/test/browser_thumbnails_storage_migrate3.js
++++ b/toolkit/components/thumbnails/test/browser_thumbnails_storage_migrate3.js
+@@ -73,18 +73,6 @@ function* runTests() {
+     "no-overwrite-plz",
+     "existing thumbnail was not overwritten"
+   );
+-
+-  // Sanity check: ensure that, until it is removed, deprecated
+-  // function |getFileForURL| points to the same path as
+-  // |getFilePathForURL|.
+-  if ("getFileForURL" in PageThumbsStorage) {
+-    file = PageThumbsStorage.getFileForURL(URL);
+-    is(
+-      file.path,
+-      PageThumbsStorageService.getFilePathForURL(URL),
+-      "Deprecated getFileForURL and getFilePathForURL return the same path"
+-    );
+-  }
+ }
+ 
+ function changeLocation(aLocation, aNewDir) {

--- a/doc/a3.md
+++ b/doc/a3.md
@@ -1,8 +1,8 @@
 Bug URL: https://bugzilla.mozilla.org/show_bug.cgi?id=894391
 
-Patch File URL: https://github.com/shn97/gecko-dev/blob/bug-894391-fix2/doc/894391.patch
+Patch File URL: https://github.com/shn97/gecko-dev/blob/bug-894391-fix3/doc/894391.patch
 
-Pull Request URL:
+Pull Request URL: https://github.com/shn97/gecko-dev/pull/3
 
 # Diagnosis
 The function `getFileForURL()` in `PageThumbs.jsm`is deprecated. A new function `getFilePathForURL()` has been added to replace it. Since the deprecated method is redundant, the code becomes harder to maintain and is confusing for new developers to understand. It is also possible for developers to use the deprecated function and create bugs. Therefore, `getFileForURL()` should be removed to improve code readability and avoid confusion and potential incorrect uses of the function among other developers. The tests referencing this function should also be removed since they will fail and cause errors for the test suite. Since `getFileForURL()` has been deprecated for 2 years and over 23 releases, it is unlikely that other parts of the project apart from tests will be referencing this function and is safe to be removed.

--- a/doc/a3.md
+++ b/doc/a3.md
@@ -1,0 +1,17 @@
+Bug URL: https://bugzilla.mozilla.org/show_bug.cgi?id=894391
+
+Patch File URL: https://github.com/shn97/gecko-dev/blob/bug-894391-fix2/doc/894391.patch
+
+Pull Request URL:
+
+# Diagnosis
+The function `getFileForURL()` in `PageThumbs.jsm`is deprecated. A new function `getFilePathForURL()` has been added to replace it. Since the deprecated method is redundant, the code becomes harder to maintain and is confusing for new developers to understand. It is also possible for developers to use the deprecated function and create bugs. Therefore, `getFileForURL()` should be removed to improve code readability and avoid confusion and potential incorrect uses of the function among other developers. The tests referencing this function should also be removed since they will fail and cause errors for the test suite. Since `getFileForURL()` has been deprecated for 2 years and over 23 releases, it is unlikely that other parts of the project apart from tests will be referencing this function and is safe to be removed.
+
+# Solution
+The function `getFileForURL()` on line 691 - 700 which is defined in `PageThumbs.jsm` is removed. There is only one test that references this function. It is a sanity check on line 77 - 87 located in `browser_thumbnails_storage_migrate3.js` and is removed.
+
+# Testing
+- After applying the patch, check if there are any occurrences of `getFileForURL` left in the project. Before the patch, there are multiple occurrences of `getFileForURL` in the `PageThumbs.jsm` and `browser_thumbnails_storage_migrate3.js`. After the patch, there are no results when searching for the string `getFileForURL` in the whole project which verifies the function and all its references are removed.
+- run `./mach lint -l eslint toolkit/components/thumbnails/PageThumbs.jsm` and `./mach lint -l eslint toolkit/components/thumbnails/test/browser_thumbnails_storage_migrate3.js` to verify there are no code style errors and warnings.
+- run `./mach build` to verify Firefox still builds correctly.
+- run `./mach test toolkit/components/thumbnails/test` to verify the removals didn't cause existing tests to fail.

--- a/toolkit/components/thumbnails/PageThumbs.jsm
+++ b/toolkit/components/thumbnails/PageThumbs.jsm
@@ -30,9 +30,7 @@ XPCOMUtils.defineLazyGlobalGetters(this, ["FileReader"]);
 
 XPCOMUtils.defineLazyModuleGetters(this, {
   Services: "resource://gre/modules/Services.jsm",
-  FileUtils: "resource://gre/modules/FileUtils.jsm",
   PlacesUtils: "resource://gre/modules/PlacesUtils.jsm",
-  Deprecated: "resource://gre/modules/Deprecated.jsm",
   AsyncShutdown: "resource://gre/modules/AsyncShutdown.jsm",
   PageThumbUtils: "resource://gre/modules/PageThumbUtils.jsm",
   PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.jsm",
@@ -687,16 +685,6 @@ var PageThumbsStorage = {
         throw err;
       }
     };
-  },
-
-  // Deprecated, please do not use
-  getFileForURL: function Storage_getFileForURL_DEPRECATED(aURL) {
-    Deprecated.warning(
-      "PageThumbs.getFileForURL is deprecated. Please use PageThumbs.getFilePathForURL and OS.File",
-      "https://developer.mozilla.org/docs/JavaScript_OS.File"
-    );
-    // Note: Once this method has been removed, we can get rid of the dependency towards FileUtils
-    return new FileUtils.File(PageThumbsStorageService.getFilePathForURL(aURL));
   },
 };
 

--- a/toolkit/components/thumbnails/test/browser_thumbnails_storage_migrate3.js
+++ b/toolkit/components/thumbnails/test/browser_thumbnails_storage_migrate3.js
@@ -73,18 +73,6 @@ function* runTests() {
     "no-overwrite-plz",
     "existing thumbnail was not overwritten"
   );
-
-  // Sanity check: ensure that, until it is removed, deprecated
-  // function |getFileForURL| points to the same path as
-  // |getFilePathForURL|.
-  if ("getFileForURL" in PageThumbsStorage) {
-    file = PageThumbsStorage.getFileForURL(URL);
-    is(
-      file.path,
-      PageThumbsStorageService.getFilePathForURL(URL),
-      "Deprecated getFileForURL and getFilePathForURL return the same path"
-    );
-  }
 }
 
 function changeLocation(aLocation, aNewDir) {


### PR DESCRIPTION
Fixed Bug 894391 - Remove deprecated PageThumbs.getFileForURL from PageThumbs.jsm and removed tests referencing the function.